### PR TITLE
Allow as descendant of ServerScriptService

### DIFF
--- a/GameAnalyticsSDK/GameAnalyticsServer.server.lua
+++ b/GameAnalyticsSDK/GameAnalyticsServer.server.lua
@@ -8,7 +8,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local ServerStorage = game:GetService("ServerStorage")
 
 --Validate
-if script:IsDescendantOf(game:GetService("ServerScriptService")) then
+if not script:IsDescendantOf(game.ServerScriptService) then
     error("GameAnalytics: Disabled server. GameAnalyticsServer has to be located in game.ServerScriptService.")
     return
 end

--- a/GameAnalyticsSDK/GameAnalyticsServer.server.lua
+++ b/GameAnalyticsSDK/GameAnalyticsServer.server.lua
@@ -8,7 +8,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local ServerStorage = game:GetService("ServerStorage")
 
 --Validate
-if script.Parent.ClassName ~= "ServerScriptService" then
+if script:IsDescendantOf("ServerScriptService") then
     error("GameAnalytics: Disabled server. GameAnalyticsServer has to be located in game.ServerScriptService.")
     return
 end

--- a/GameAnalyticsSDK/GameAnalyticsServer.server.lua
+++ b/GameAnalyticsSDK/GameAnalyticsServer.server.lua
@@ -8,7 +8,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local ServerStorage = game:GetService("ServerStorage")
 
 --Validate
-if script:IsADescendantOf(game:GetService("ServerScriptService")) then
+if script:IsDescendantOf(game:GetService("ServerScriptService")) then
     error("GameAnalytics: Disabled server. GameAnalyticsServer has to be located in game.ServerScriptService.")
     return
 end

--- a/GameAnalyticsSDK/GameAnalyticsServer.server.lua
+++ b/GameAnalyticsSDK/GameAnalyticsServer.server.lua
@@ -8,7 +8,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local ServerStorage = game:GetService("ServerStorage")
 
 --Validate
-if script:IsDescendantOf("ServerScriptService") then
+if script:IsADescendantOf(game:GetService("ServerScriptService")) then
     error("GameAnalytics: Disabled server. GameAnalyticsServer has to be located in game.ServerScriptService.")
     return
 end

--- a/GameAnalyticsSDK/GameAnalyticsServer.server.lua
+++ b/GameAnalyticsSDK/GameAnalyticsServer.server.lua
@@ -8,7 +8,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local ServerStorage = game:GetService("ServerStorage")
 
 --Validate
-if not script:IsDescendantOf(game.ServerScriptService) then
+if not script:IsDescendantOf(game:GetService("ServerScriptService")) then
     error("GameAnalytics: Disabled server. GameAnalyticsServer has to be located in game.ServerScriptService.")
     return
 end


### PR DESCRIPTION
Allows the script to be put anywhere within ServerScriptService - it isn't ideal to have the scripts as immediate children if your server script hierarchy is laid out through folders.