### PR TITLE
Fix error on ga:PlayerRemoved()

### DIFF
--- a/GameAnalyticsSDK/GameAnalytics/init.lua
+++ b/GameAnalyticsSDK/GameAnalytics/init.lua
@@ -451,7 +451,7 @@ function ga:PlayerRemoved(Player)
     store:SavePlayerData(Player)
 
     local PlayerData = store.PlayerCache[Player.UserId]
-    if not PlayerData.PlayerTeleporting then
+    if PlayerData and not PlayerData.PlayerTeleporting then
         ga:endSession(Player.UserId)
     end
 end


### PR DESCRIPTION
Players leaving before data was loaded and cached caused error:
ServerStorage.GameAnalytics:454: attempt to index a nil value
    Stack Begin
    Script 'ServerStorage.GameAnalytics', Line 454 - function PlayerRemoved
    Script 'ServerScriptService.GameAnalyticsServer