### PR TITLE
Added ga:filterForBusinessEvent()

### DIFF
--- a/GameAnalyticsSDK/GameAnalytics/init.lua
+++ b/GameAnalyticsSDK/GameAnalytics/init.lua
@@ -170,6 +170,10 @@ function ga:endSession(playerId)
     end)
 end
 
+function ga:filterForBusinessEvent(text)
+	return string.gsub(text, "[^A-Za-z0-9%s%-_%.%(%)!%?]", "")
+end
+
 function ga:addBusinessEvent(playerId, options)
     threading:performTaskOnGAThread(function()
         if not state:isEventSubmissionEnabled() then

--- a/GameAnalyticsSDK/GameAnalytics/init.lua
+++ b/GameAnalyticsSDK/GameAnalytics/init.lua
@@ -486,7 +486,7 @@ function ga:ProcessReceiptCallback(Info)
     ga:addBusinessEvent(Info.PlayerId, {
         amount = Info.CurrencySpent,
         itemType = "DeveloperProduct",
-        itemId = ProductInfo.Name
+        itemId = ga:filterForBusinessEvent(ProductInfo.Name)
     })
 end
 

--- a/GameAnalyticsSDK/GameAnalyticsServer.server.lua
+++ b/GameAnalyticsSDK/GameAnalyticsServer.server.lua
@@ -139,7 +139,7 @@ MKT.PromptGamePassPurchaseFinished:Connect(function(Player, ID, Purchased)
     GameAnalytics:addBusinessEvent(Player.UserId, {
         amount = GamepassInfo.PriceInRobux,
         itemType = "Gamepass",
-        itemId = GamepassInfo.Name
+        itemId = GameAnalytics:filterForBusinessEvent(GamepassInfo.Name)
     })
 end)
 


### PR DESCRIPTION
To prevent events from failing to be logged, I propose this feature is added so developers can name their products to whatever they desire without having to worry about, or causing issues when processing the business event.