### PR TITLE
'ypcall' is deprecated and should be replaced with 'pcall'.

### DIFF
--- a/GameAnalyticsSDK/GameAnalytics/HttpApi/init.lua
+++ b/GameAnalyticsSDK/GameAnalytics/HttpApi/init.lua
@@ -138,7 +138,7 @@ function http_api:initRequest(gameKey, secretKey, playerData, playerId)
 
 	--Response
 	local responseBody
-	success = ypcall(function()
+	success = pcall(function()
 		responseBody = HTTP:JSONDecode(res.Body)
 	end)
 
@@ -229,7 +229,7 @@ function http_api:sendEventsInArray(gameKey, secretKey, eventArray)
 	end
 
 	local responseBody
-	ypcall(function()
+	pcall(function()
 		responseBody = HTTP:JSONDecode(res.Body)
 	end)
 


### PR DESCRIPTION
See https://roblox.github.io/luau/lint.html. Usage of ypcall adds warnings to the 'Script Analysis' window in Roblox Studio.