### PR TITLE
Fix error when logging events associated with no player

### DIFF
--- a/GameAnalyticsSDK/GameAnalytics/Events.lua
+++ b/GameAnalyticsSDK/GameAnalytics/Events.lua
@@ -108,6 +108,7 @@ local function getEventAnnotations(playerId)
 			Platform = "uwp_desktop",
 			SessionID = DUMMY_SESSION_ID,
 			Sessions = 1,
+			CustomUserId = "Server"
 		}
 	end
 


### PR DESCRIPTION
Fixes #90

I'm unsure how you want `user_id` to look when the event is associated with no player, but this _works_ as it is. Feel free to change or request changes.